### PR TITLE
Add dockerfile_path variable to cloudbuild-trigger module

### DIFF
--- a/modules/cloudbuild-trigger/README.md
+++ b/modules/cloudbuild-trigger/README.md
@@ -41,6 +41,7 @@ module "cloudbuild_trigger_main_branch" {
   infra_project     = "gfw-int-infrastructure"   # Defaults to "gfw-int-infrastructure"
   registry_location = "us-central1"              # Defaults to "us-central1"
   trigger_location  = "us-central1"              # Defaults to "us-central1"
+  dockerfile_path   = "Dockerfile"               # Defaults to "Dockerfile"
 
   # --- Trigger-specific Settings ---
   # This instance is configured for a branch trigger:

--- a/modules/cloudbuild-trigger/main.tf
+++ b/modules/cloudbuild-trigger/main.tf
@@ -1,5 +1,4 @@
 locals {
-  dockerfile_path             = var.dockerfile_path != null ? var.dockerfile_path : "Dockerfile"
   trigger_description_tag     = "Publishes a Docker image for tags matching the specified pattern."
   trigger_description_branch  = "Publishes a Docker image for branches matching the specified pattern."
   trigger_description_default = var.tag != null ? local.trigger_description_tag : local.trigger_description_branch
@@ -35,7 +34,7 @@ resource "google_cloudbuild_trigger" "trigger" {
   service_account = local.service_account
 
   substitutions = {
-    _DOCKERFILE_PATH = local.dockerfile_path
+    _DOCKERFILE_PATH = var.dockerfile_path
     _IMAGE_NAME      = local.image_name
     _TAG_NAME        = local.tag_name
     _PLATFORM        = var.platform

--- a/modules/cloudbuild-trigger/main.tf
+++ b/modules/cloudbuild-trigger/main.tf
@@ -36,9 +36,9 @@ resource "google_cloudbuild_trigger" "trigger" {
 
   substitutions = {
     _DOCKERFILE_PATH = local.dockerfile_path
-    _IMAGE_NAME = local.image_name
-    _TAG_NAME   = local.tag_name
-    _PLATFORM   = var.platform
+    _IMAGE_NAME      = local.image_name
+    _TAG_NAME        = local.tag_name
+    _PLATFORM        = var.platform
 
   }
 

--- a/modules/cloudbuild-trigger/main.tf
+++ b/modules/cloudbuild-trigger/main.tf
@@ -1,4 +1,5 @@
 locals {
+  dockerfile_path             = var.dockerfile_path != null ? var.dockerfile_path : "Dockerfile"
   trigger_description_tag     = "Publishes a Docker image for tags matching the specified pattern."
   trigger_description_branch  = "Publishes a Docker image for branches matching the specified pattern."
   trigger_description_default = var.tag != null ? local.trigger_description_tag : local.trigger_description_branch
@@ -34,6 +35,7 @@ resource "google_cloudbuild_trigger" "trigger" {
   service_account = local.service_account
 
   substitutions = {
+    _DOCKERFILE_PATH = local.dockerfile_path
     _IMAGE_NAME = local.image_name
     _TAG_NAME   = local.tag_name
     _PLATFORM   = var.platform
@@ -81,6 +83,7 @@ resource "google_cloudbuild_trigger" "trigger" {
         "buildx", "build",
         "--platform", "$_PLATFORM",
         "-t", "$_IMAGE_NAME:$_TAG_NAME",
+        "-f", "$_DOCKERFILE_PATH",
         "--target", "prod",
         "--push",
         "."

--- a/modules/cloudbuild-trigger/test.tftest.hcl
+++ b/modules/cloudbuild-trigger/test.tftest.hcl
@@ -13,6 +13,7 @@ variables {
   infra_project     = "mock-infra-project"
   registry_location = "us-central1"
   trigger_location  = "us-central1"
+  dockerfile_path   = "path/to/test.Dockerfile"
 }
 
 run "basic_trigger_creation_plan" {

--- a/modules/cloudbuild-trigger/variables.tf
+++ b/modules/cloudbuild-trigger/variables.tf
@@ -39,6 +39,12 @@ variable "repo_owner" {
 
 }
 
+variable "dockerfile_path" {
+  description = "Specifies the Dockerfile to use."
+  type        = string
+  default     = "Dockerfile"
+}
+
 variable "branch" {
   description = "Branch to trigger on."
   type        = string


### PR DESCRIPTION
This change will helps to build the image repositories where the Dockerfile file changes its path or name.

- Adds the `dockerfile_path` variable to the variables file.
- Adds the `-f` option in `buildx build` step to indicate the `Dockerfile`.
- Include the variable `dockerfile_path` in the test.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-3552