### PR TITLE
Fixes monorepo tag parsing using $TAG_NAME instead of var.tag

### DIFF
--- a/modules/cloudbuild-trigger/main.tf
+++ b/modules/cloudbuild-trigger/main.tf
@@ -5,8 +5,8 @@ locals {
   trigger_description         = var.trigger_description != null ? var.trigger_description : local.trigger_description_default
   trigger_suffix              = var.gke_deploy_enabled ? "tag-deploy" : "${var.tag != null ? "tag" : var.branch}"
   service_account             = "projects/${var.infra_project}/serviceAccounts/cloudbuild@${var.infra_project}.iam.gserviceaccount.com"
-  monorepo_suffix             = (var.tag != null && strcontains(var.tag, "@")) ? trimprefix(split("@", var.tag)[0], var.repo_name) : ""
-  monorepo_tag                = (var.tag != null && strcontains(var.tag, "@")) ? split("@", var.tag)[1] : ""
+  monorepo_suffix             = (var.tag != null && strcontains(var.tag, "@")) ? regex("${var.repo_name}(.*)(?:@)", var.tag)[0] : ""
+  monorepo_tag                = (var.tag != null && strcontains(var.tag, "@")) ? "$${TAG_NAME#*@}" : ""
   image_name                  = "${var.registry_location}-docker.pkg.dev/${var.infra_project}/${var.registry_artifact}/${var.repo_name}${local.monorepo_suffix}"
   tag_name                    = var.tag == null ? "$BRANCH_NAME" : (strcontains(var.tag, "@") ? local.monorepo_tag : "$TAG_NAME")
 }

--- a/modules/cloudbuild-trigger/test_tag.tftest.hcl
+++ b/modules/cloudbuild-trigger/test_tag.tftest.hcl
@@ -6,7 +6,7 @@ variables {
   repo_name    = "my-app-repo"
   repo_owner   = "my-org"
   branch       = null
-  tag          = "my-app-repo-package@1.0.0"
+  tag          = "^my-app-repo-package@.*$"
   invert_regex = false
 
   registry_artifact = "my-docker-registry"
@@ -22,5 +22,10 @@ run "basic_tag_trigger_creation_plan" {
   assert {
     condition     = google_cloudbuild_trigger.trigger.name == "my-app-repo-package-tag"
     error_message = "Expected trigger name to be 'my-app-repo-package-tag'."
+  }
+
+  assert {
+    condition     = google_cloudbuild_trigger.trigger.github[0].push[0].tag == "^my-app-repo-package@.*$"
+    error_message = "Expected trigger tag to be '^my-app-repo-package@.*$'."
   }
 }


### PR DESCRIPTION
The `var.tag` has the filter pattern of tags used by the trigger. The `monorepo_tag` should be using the value of the tag created defined by `$TAG_NAME`. Fixing this assignment.
The way the parsing was done changes because `$TAG_NAME` is not part of `HCL` and should be parsing with bash parameter expansion.